### PR TITLE
mavros Command Home (test)

### DIFF
--- a/detect_avoid_files/src/avoid.cpp
+++ b/detect_avoid_files/src/avoid.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv){
     ////////////////////////////////////////////
     ros::ServiceClient wp_clear_client = p.serviceClient<mavros_msgs::WaypointClear>("/mavros/mission/clear"); //("waypoint_clear_client")
     ros::ServiceClient wp_srv_client = n.serviceClient<mavros_msgs::WaypointPush>("waypoint_push_client");
-    ros::ServiceClient set_home_client = l.serviceClient<mavros_msgs::CommandHome>("command_home_client");
+    ros::ServiceClient set_home_client = l.serviceClient<mavros_msgs::CommandHome>("/mavros/mission/home"); //("command_home_client")
 
     mavros_msgs::WaypointPush wp_push_srv;
     mavros_msgs::WaypointClear wp_clear_srv;


### PR DESCRIPTION
Testing Command home changed from  ros::ServiceClient set_home_client = l.serviceClient<mavros_msgs::CommandHome>("command_home_client") to ros::ServiceClient set_home_client = l.serviceClient<mavros_msgs::CommandHome>("/mavros/mission/home"); to